### PR TITLE
Make critical notifications expireable, respect -t --expire-time options

### DIFF
--- a/xfce4-notifyd/xfce-notify-daemon.c
+++ b/xfce4-notifyd/xfce-notify-daemon.c
@@ -1451,8 +1451,10 @@ notify_notify(XfceNotifyFdoGBus *skeleton,
     }
 
     notify_update_known_applications (xndaemon->settings, new_app_name);
-
-    if (expire_timeout == -1 || !xndaemon->expire_timeout_allow_override) {
+    // If -t unused and -u critical, keep the default notify-send behaviour where criticals are persistent. 
+    if (expire_timeout == -1 && urgency == XFCE_NOTIFY_URGENCY_CRITICAL) {
+        expire_timeout = 0; 
+    } else if (expire_timeout == -1 || !xndaemon->expire_timeout_allow_override) {
         expire_timeout = xndaemon->expire_timeout_enabled ? xndaemon->expire_timeout : 0;
     }
 

--- a/xfce4-notifyd/xfce-notify-window.c
+++ b/xfce4-notifyd/xfce-notify-window.c
@@ -351,7 +351,7 @@ xfce_notify_window_init(XfceNotifyWindow *window)
 static void
 xfce_notify_window_start_expiration(XfceNotifyWindow *window)
 {
-    if (window->expire_timeout > 0 && window->urgency != XFCE_NOTIFY_URGENCY_CRITICAL) {
+    if (window->expire_timeout > 0) {
         gint64 ct;
         guint timeout;
         gboolean fade_transparent;


### PR DESCRIPTION
Branched off of [0.8.2](https://github.com/xfce-mirror/xfce4-notifyd/tree/xfce4-notifyd-0.8.2)

Before:
 `notify-send -u critical -t 5000`
Result: 
Never-expiring critical notification despite setting 5s.
After:
Notification disapears after 5 seconds.

If -t is unused, 0 is assumed for criticals making them persistent - so the default use case is unaffected, non-breaking change.